### PR TITLE
add --disable-dev-shm-usage to chrome flags

### DIFF
--- a/lighthouse/runner.py
+++ b/lighthouse/runner.py
@@ -116,7 +116,7 @@ class LighthouseRunner:
                 'lighthouse',
                 url,
                 '--quiet' if quiet else '',
-                '--chrome-flags="--headless --no-sandbox"',
+                '--chrome-flags="--headless --no-sandbox --disable-dev-shm-usage"',
                 '--preset=perf',
                 '--emulated-form-factor={0}'.format(form_factor),
                 '--output=json',

--- a/lighthouse/runner.py
+++ b/lighthouse/runner.py
@@ -122,6 +122,7 @@ class LighthouseRunner:
                 '--output=json',
                 '--output=html',
                 '--output-path={0}'.format(self.report_path),
+                '--no-enable-error-reporting',
             ]
 
             # Run the Lighthouse CLI command


### PR DESCRIPTION
There is a common error for Lighthouse described here:

https://github.com/GoogleChrome/lighthouse-ci/issues/504#issuecomment-740716892

and here:

https://github.com/GoogleChrome/lighthouse/issues/6512#issuecomment-925185412

cause this error:

```
  LH:ChromeLauncher Killing Chrome instance 37 +1ms
Runtime error encountered: Waiting for DevTools protocol response has exceeded the allotted time. (Method: Network.setUserAgentOverride)
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/lighthouse/runner.py", line 129, in _run
    subprocess.check_call(' '.join(command), shell=True)
  File "/usr/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'lighthouse https://potaris.de/en-gb/posts/automx/  --chrome-flags="--headless --no-sandbox" --preset=perf --emulated-form-factor=desktop --output=json --output=html --output-path=/tmp/2024-01-29_15:35:48.115571_1461f67834ea4ec5a9a14e4de2ea0fdd' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "//app/checks.py", line 151, in check_url
    result_dict.update({"lighthouse" : check_lighthouse_f(url)})
                                       ^^^^^^^^^^^^^^^^^^^^^^^
  File "//app/checks.py", line 38, in check_lighthouse_f
    report = LighthouseRunner(url, form_factor='desktop', quiet=False, timings=TIMINGS).report
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/lighthouse/runner.py", line 84, in __init__
    self._run(url, form_factor, quiet, additional_settings)
  File "/usr/local/lib/python3.11/dist-packages/lighthouse/runner.py", line 133, in _run
    raise RuntimeError(msg)
RuntimeError: Command 'lighthouse https://potaris.de/en-gb/posts/automx/  --chrome-flags="--headless --no-sandbox" --preset=perf --emulated-form-factor=desktop --output=json --output=html --output-path=/tmp/2024-01-29_15:35:48.115571_1461f67834ea4ec5a9a14e4de2ea0fdd' returned an error code: 1, output: None
```

as described in the Issues, this can be fixed with:

```
--disable-dev-shm-usage
```

honestly a shame that lighthouse and chrome devs are pointing fingers at each other for years about this now instead of fixing it, but uh well...

Here is a Dockerfile for testing (with my repo & changes): https://github.com/FAUSheppy/atlantis-website-monitoring/blob/master/worker/Dockerfile

Try with:
```
docker build . -t test; docker kill test; docker rm test; docker run --name test -d test;
docker exec -it test /bin/bash
>  python3 -i app/checks.py
>  > check_url("https://potaris.de/en-gb/posts/automx/", True, True, False)
```
